### PR TITLE
Add macOS build support with NDI SDK for Apple

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Builds FFMPEG with NDI enabled
 
+## Linux
+
 ### Download required installation files
 
 Make sure git is installed.
@@ -78,7 +80,7 @@ Extract the downloaded NDI Advanced SDK .tar file and copy it to the ffmpeg dire
 sudo bash ../FFMPEG-NDI/install-ndi-generic-armhf.sh
 ```
 
-## Build and Install FFMPEG
+### Build and Install FFMPEG (Linux)
 The following is the bare minimum needed for sending and receiving NDI and more options can be added for a more feature filled FFMPEG build.
 ```
 ./configure --enable-nonfree --enable-libndi_newtek
@@ -87,6 +89,74 @@ sudo make install
 ```
 Installation is now complete
 
+---
+
+## macOS
+
+### Prerequisites
+
+Install [Homebrew](https://brew.sh) if you don't have it, then clone the repositories:
+
+```
+git clone https://github.com/lplassman/FFMPEG-NDI.git
+git clone https://git.ffmpeg.org/ffmpeg.git && cd ffmpeg
+git checkout n5.1
+```
+
+### Install the NDI SDK for Apple
+
+Download and install the NDI SDK for Apple from [ndi.video](https://ndi.video/for-developers/ndi-sdk/download/). The installer places files in `/Library/NDI SDK for Apple/` by default.
+
+### Apply Patches
+
+```
+git config user.email "you@example.com"
+git am ../FFMPEG-NDI/libndi.patch
+cp ../FFMPEG-NDI/libavdevice/libndi_newtek_* libavdevice/
+```
+
+### Install build prerequisites
+
+```
+bash ../FFMPEG-NDI/preinstall-macos.sh
+```
+
+### Install NDI libraries to system paths
+
+This copies headers and libraries from the NDI SDK to `/usr/local/` so FFmpeg's configure can find them:
+
+```
+sudo bash ../FFMPEG-NDI/install-ndi-macos.sh
+```
+
+### Apply mathops patch (Intel Macs only)
+
+If building on an Intel Mac, apply the clang inline assembly fix:
+
+```
+git am ../FFMPEG-NDI/mathops.patch
+```
+
+This patch is not needed on Apple Silicon (ARM64) Macs.
+
+### Build and Install FFMPEG (macOS)
+
+```
+./configure --enable-nonfree --enable-libndi_newtek
+make -j $(sysctl -n hw.ncpu)
+sudo make install
+```
+
+If the NDI headers or libraries are not found, you can specify their paths explicitly:
+
+```
+./configure --enable-nonfree --enable-libndi_newtek \
+    --extra-cflags="-I/Library/NDI SDK for Apple/include" \
+    --extra-ldflags="-L/Library/NDI SDK for Apple/lib/macOS"
+```
+
+---
+
 ## Usage for FFMPEG with NDI
 
 List all sources on the network
@@ -94,9 +164,14 @@ List all sources on the network
 ffmpeg -f libndi_newtek -find_sources 1 -i dummy
 ```
 
-Stream a webcam to NDI
+Stream a webcam to NDI (Linux)
 ```
 ffmpeg -f v4l2 -framerate 30 -video_size 1280x720 -pixel_format mjpeg -i /dev/video1 -f libndi_newtek -pix_fmt uyvy422 CameraOut
+```
+
+Stream a webcam to NDI (macOS)
+```
+ffmpeg -f avfoundation -framerate 30 -video_size 1280x720 -i "0" -f libndi_newtek -pix_fmt uyvy422 CameraOut
 ```
 
 Monitor a NDI stream

--- a/install-ndi-macos.sh
+++ b/install-ndi-macos.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env sh
+
+# Install NDI SDK headers and libraries on macOS for FFmpeg compilation.
+#
+# Prerequisites: Download and install the NDI SDK for Apple from https://ndi.video/for-developers/ndi-sdk/download/
+# The installer places files in /Library/NDI SDK for Apple/ by default.
+
+set -eu
+
+NDI_SDK_DIR="/Library/NDI SDK for Apple"
+INCLUDE_DIR="/usr/local/include"
+LIB_DIR="/usr/local/lib"
+
+if [ ! -d "$NDI_SDK_DIR" ]; then
+    echo "Error: NDI SDK for Apple not found at '$NDI_SDK_DIR'."
+    echo ""
+    echo "Please download and install the NDI SDK from:"
+    echo "  https://ndi.video/for-developers/ndi-sdk/download/"
+    echo ""
+    echo "After installing, re-run this script."
+    exit 1
+fi
+
+if [ ! -d "$NDI_SDK_DIR/include" ]; then
+    echo "Error: NDI SDK include directory not found at '$NDI_SDK_DIR/include'."
+    exit 1
+fi
+
+if [ ! -d "$NDI_SDK_DIR/lib/macOS" ]; then
+    echo "Error: NDI SDK macOS library directory not found at '$NDI_SDK_DIR/lib/macOS'."
+    exit 1
+fi
+
+echo "Installing NDI SDK headers and libraries..."
+
+# Create target directories if needed
+mkdir -p "$INCLUDE_DIR"
+mkdir -p "$LIB_DIR"
+
+# Copy headers
+cp "$NDI_SDK_DIR"/include/* "$INCLUDE_DIR"/
+echo "  Headers installed to $INCLUDE_DIR/"
+
+# Copy libraries
+cp "$NDI_SDK_DIR"/lib/macOS/* "$LIB_DIR"/
+echo "  Libraries installed to $LIB_DIR/"
+
+echo "Done"

--- a/install-ndi-macos.sh
+++ b/install-ndi-macos.sh
@@ -38,7 +38,7 @@ mkdir -p "$INCLUDE_DIR"
 mkdir -p "$LIB_DIR"
 
 # Copy headers
-cp "$NDI_SDK_DIR"/include/* "$INCLUDE_DIR"/
+cp -p "$NDI_SDK_DIR"/include/* "$INCLUDE_DIR"/
 echo "  Headers installed to $INCLUDE_DIR/"
 
 # Copy libraries

--- a/preinstall-macos.sh
+++ b/preinstall-macos.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env sh
+
+# Install prerequisites for building FFmpeg with NDI on macOS
+# Requires Homebrew (https://brew.sh)
+
+set -eu
+
+if ! command -v brew >/dev/null 2>&1; then
+    echo "Error: Homebrew is not installed."
+    echo "Install it from https://brew.sh"
+    exit 1
+fi
+
+echo "Installing build prerequisites via Homebrew..."
+
+brew install \
+    automake \
+    cmake \
+    git \
+    libass \
+    libtool \
+    libvorbis \
+    meson \
+    nasm \
+    ninja \
+    openssl \
+    pkg-config \
+    sdl2 \
+    texinfo \
+    wget \
+    yasm \
+    zlib
+
+echo "Done installing prerequisites."
+echo "Note: macOS includes Bonjour (mDNS) natively — no separate Avahi install needed."


### PR DESCRIPTION
- Add preinstall-macos.sh: Homebrew-based prerequisite installation
- Add install-ndi-macos.sh: copies NDI SDK headers/libs from /Library/NDI SDK for Apple/ to /usr/local/ (reuses pattern from typescape/NDI-Recorder macOS port)
- Update README.md with full macOS build instructions, avfoundation webcam example, and sysctl-based parallel make
